### PR TITLE
chore: ignore css folder which contains transpiled css files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,6 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Ignore generated files
+/css

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-dist
+/dist
+
+/css

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Ignore generated files
+/css


### PR DESCRIPTION
The reason why we need to ignore the css folder is that these are just generated files.

 `build` or `dev` scripts generates these and they are not run through the prettier or linter.  Code linting within the `check` github action fails.

![Screenshot 2024-04-11 at 14 35 41](https://github.com/diete-design/diete.design/assets/7974813/1ef4248a-0bf6-4d4a-a78a-00268f05ab4d)
