### PR TITLE
wip: import css files as asset

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,4 +14,4 @@ package-lock.json
 yarn.lock
 
 # Ignore generated files
-/static/css
+/static/generated/css

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /dist
 
-/css
+/static/generated/css

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,4 @@ package-lock.json
 yarn.lock
 
 # Ignore generated files
-/static/css
+/static/generated/css

--- a/src/routes/csstest/+page.svelte
+++ b/src/routes/csstest/+page.svelte
@@ -3,7 +3,7 @@
 	let css: string | undefined
 
 	onMount(async () => {
-		const response = await fetch('/css/ui/button.css')
+		const response = await fetch('/generated/css/ui/button.css')
 		css = await response.text()
 	})
 </script>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,7 +2,7 @@ import adapter from '@sveltejs/adapter-auto'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import fs from 'fs'
 
-const DIST_DIR = './static/css'
+const DIST_DIR = './static/generated/css'
 
 function cssPreprocess() {
 	const vite = vitePreprocess()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,4 @@ export default defineConfig({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 	},
-	assetsInclude: ['static/css/**/*.css'],
 })


### PR DESCRIPTION
After trying out several different ways to do this I settled with dynamically loading the generated CSS with `fetch`, because this works the most reliable.

I got the raw imports to work as well (e.g. `import css from '$lib/../../static/css/ui/button.css?raw`) but that had a circular reference issue when building and generating the assets the first time. That solution also required to put a declaration like this in an `index.d.ts` in a folder that used the css files:
```typescript
declare module '*.css?raw' {
	const content: string
	export default content
}
```
The generated files must be in a folder that is available during both build time and run time, so I decided to put everything in `/static/css`. This is also a requirement for raw importing the file.

I added a test page under `/csstest` to show how it works, it just displays the generated css style of the button component. This can be removed after the review.