### PR TITLE
fix: button focused state

### DIFF
--- a/src/lib/components/custom/dropdown.svelte
+++ b/src/lib/components/custom/dropdown.svelte
@@ -56,7 +56,7 @@
 	aria-controls={dropdownId}
 >
 	<div on:click={onClick} on:keypress={onClick} role="button" tabindex={0}>
-		<Button variant="overlay" active={showDropdown}>{@render button()}</Button>
+		<Button variant="solid" active={showDropdown}>{@render button()}</Button>
 	</div>
 
 	<div class={`root`} aria-hidden={!showDropdown}>

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
 	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements'
-	type Variant = 'strong' | 'secondary' | 'ghost' | 'overlay' | 'darkoverlay'
+	type Variant = 'strong' | 'secondary' | 'ghost' | 'solid' | 'darkoverlay'
 	type Dimension = 'default' | 'large' | 'compact' | 'small'
 	type ButtonProps = {
 		variant?: Variant
@@ -200,7 +200,7 @@
 			color: var(--colors-high);
 		}
 	}
-	.overlay {
+	.solid {
 		border: 1px solid var(--colors-base);
 		background: var(--colors-base);
 		color: var(--colors-ultra-high);

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -235,11 +235,11 @@
 
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
-			outline: 4px solid var(--colors-dark-base);
+			outline: 4px solid var(--colors-top);
 			outline-offset: -4px;
 			border: 1px solid transparent;
-			background: var(--colors-dark-top);
-			color: var(--colors-dark-base);
+			background: var(--colors-base);
+			color: var(--colors-top);
 		}
 
 		&:hover:not(:disabled),

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -122,7 +122,6 @@
 		background: var(--colors-ultra-high);
 		color: var(--colors-ultra-low);
 
-		&:focus:not(:disabled),
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
 			outline: 4px solid var(--colors-top);
@@ -144,7 +143,6 @@
 			border: 1px solid var(--colors-high);
 			background: var(--colors-high);
 			color: var(--colors-base);
-			outline: none;
 		}
 	}
 	.secondary {
@@ -152,7 +150,6 @@
 		background: none;
 		color: var(--colors-ultra-high);
 
-		&:focus:not(:disabled),
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
 			outline: 4px solid var(--colors-top);
@@ -174,7 +171,6 @@
 			border: 1px solid var(--colors-high);
 			background: var(--colors-low);
 			color: var(--colors-high);
-			outline: none;
 		}
 	}
 	.ghost {
@@ -182,7 +178,6 @@
 		background: transparent;
 		color: var(--colors-ultra-high);
 
-		&:focus:not(:disabled),
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
 			outline: 4px solid var(--colors-top);
@@ -203,7 +198,6 @@
 			border: 1px solid var(--colors-low);
 			background: var(--colors-low);
 			color: var(--colors-high);
-			outline: none;
 		}
 	}
 	.overlay {
@@ -211,7 +205,6 @@
 		background: var(--colors-base);
 		color: var(--colors-ultra-high);
 
-		&:focus:not(:disabled),
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
 			outline: 4px solid var(--colors-top);
@@ -233,7 +226,6 @@
 			border: 1px solid var(--colors-low);
 			background: var(--colors-low);
 			color: var(--colors-high);
-			outline: none;
 		}
 	}
 	.darkoverlay {
@@ -241,14 +233,13 @@
 		background: var(--colors-dark-overlay);
 		color: var(--colors-dark-top);
 
-		&:focus:not(:disabled),
 		&:focus-visible:not(:disabled),
 		&.focus:not(:disabled) {
-			outline: 4px solid var(--colors-dark-top);
+			outline: 4px solid var(--colors-dark-base);
 			outline-offset: -4px;
 			border: 1px solid transparent;
-			background: var(--colors-dark-base);
-			color: var(--colors-dark-top);
+			background: var(--colors-dark-top);
+			color: var(--colors-dark-base);
 		}
 
 		&:hover:not(:disabled),
@@ -263,7 +254,6 @@
 			border: 1px solid var(--colors-dark-base);
 			background: var(--colors-dark-base);
 			color: var(--colors-dark-top);
-			outline: none;
 		}
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -63,7 +63,7 @@
 <svelte:window bind:innerWidth />
 
 <div class="menu-button-container">
-	<Button variant={isMenuOpen ? 'ghost' : 'overlay'} onclick={() => (isMenuOpen = !isMenuOpen)}>
+	<Button variant={isMenuOpen ? 'ghost' : 'solid'} onclick={() => (isMenuOpen = !isMenuOpen)}>
 		{#if isMenuOpen}
 			<SidePanelCloseFilled size={24} />
 		{:else}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -66,11 +66,11 @@
 				<Button variant="ghost" disabled>Ghost disabled</Button>
 			</div>
 			<div class="col">
-				<Button variant="overlay">Overlay</Button>
-				<Button variant="overlay" hover>Overlay hover</Button>
-				<Button variant="overlay" active>Overlay active</Button>
-				<Button variant="overlay" focus>Overlay focus</Button>
-				<Button variant="overlay" disabled>Overlay disabled</Button>
+				<Button variant="solid">Solid</Button>
+				<Button variant="solid" hover>Solid hover</Button>
+				<Button variant="solid" active>Solid active</Button>
+				<Button variant="solid" focus>Solid focus</Button>
+				<Button variant="solid" disabled>Solid disabled</Button>
 			</div>
 			<div class="col">
 				<Button variant="darkoverlay">Dark overlay</Button>
@@ -124,11 +124,11 @@
 				<Button dimension="large" variant="ghost" disabled>Ghost disabled</Button>
 			</div>
 			<div class="col">
-				<Button dimension="large" variant="overlay">Overlay</Button>
-				<Button dimension="large" variant="overlay" hover>Overlay hover</Button>
-				<Button dimension="large" variant="overlay" active>Overlay active</Button>
-				<Button dimension="large" variant="overlay" focus>Overlay focus</Button>
-				<Button dimension="large" variant="overlay" disabled>Overlay disabled</Button>
+				<Button dimension="large" variant="solid">Solid</Button>
+				<Button dimension="large" variant="solid" hover>Solid hover</Button>
+				<Button dimension="large" variant="solid" active>Solid active</Button>
+				<Button dimension="large" variant="solid" focus>Solid focus</Button>
+				<Button dimension="large" variant="solid" disabled>Solid disabled</Button>
 			</div>
 			<div class="col">
 				<Button dimension="large" variant="darkoverlay">Dark overlay</Button>
@@ -182,11 +182,11 @@
 				<Button dimension="compact" variant="ghost" disabled>Ghost disabled</Button>
 			</div>
 			<div class="col">
-				<Button dimension="compact" variant="overlay">Overlay</Button>
-				<Button dimension="compact" variant="overlay" hover>Overlay hover</Button>
-				<Button dimension="compact" variant="overlay" active>Overlay active</Button>
-				<Button dimension="compact" variant="overlay" focus>Overlay focus</Button>
-				<Button dimension="compact" variant="overlay" disabled>Overlay disabled</Button>
+				<Button dimension="compact" variant="solid">Solid</Button>
+				<Button dimension="compact" variant="solid" hover>Solid hover</Button>
+				<Button dimension="compact" variant="solid" active>Solid active</Button>
+				<Button dimension="compact" variant="solid" focus>Solid focus</Button>
+				<Button dimension="compact" variant="solid" disabled>Solid disabled</Button>
 			</div>
 			<div class="col">
 				<Button dimension="compact" variant="darkoverlay">Dark overlay</Button>
@@ -240,11 +240,11 @@
 				<Button dimension="small" variant="ghost" disabled>Ghost disabled</Button>
 			</div>
 			<div class="col">
-				<Button dimension="small" variant="overlay">Overlay</Button>
-				<Button dimension="small" variant="overlay" hover>Overlay hover</Button>
-				<Button dimension="small" variant="overlay" active>Overlay active</Button>
-				<Button dimension="small" variant="overlay" focus>Overlay focus</Button>
-				<Button dimension="small" variant="overlay" disabled>Overlay disabled</Button>
+				<Button dimension="small" variant="solid">Solid</Button>
+				<Button dimension="small" variant="solid" hover>Solid hover</Button>
+				<Button dimension="small" variant="solid" active>Solid active</Button>
+				<Button dimension="small" variant="solid" focus>Solid focus</Button>
+				<Button dimension="small" variant="solid" disabled>Solid disabled</Button>
 			</div>
 			<div class="col">
 				<Button dimension="small" variant="darkoverlay">Dark overlay</Button>

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -24,7 +24,7 @@
 	import Option from '$lib/components/ui/select/option.svelte'
 	import ComponentTemplate from '$lib/components/custom/component-template.svelte'
 
-	type Variant = 'strong' | 'secondary' | 'ghost' | 'overlay' | 'darkoverlay'
+	type Variant = 'strong' | 'secondary' | 'ghost' | 'solid' | 'darkoverlay'
 	type Dimension = 'default' | 'large' | 'compact' | 'small'
 
 	let css: string = $state('Loading...')
@@ -121,10 +121,10 @@ ${leftIcon || rightIcon ? `import { Close } from 'carbon-icons-svelte'` : ''}
 	</p>
 
 	<p class="example-row">
-		<Typography variant="small" bold>7. Light overlay button</Typography>
-		<Button variant="overlay">Overlay</Button>
-		<Button variant="overlay"><Launch size={24} />Open</Button>
-		<Button variant="overlay">See all<CaretRight size={24} /></Button>
+		<Typography variant="small" bold>7. Solid button</Typography>
+		<Button variant="solid">Solid</Button>
+		<Button variant="solid"><Launch size={24} />Open</Button>
+		<Button variant="solid">See all<CaretRight size={24} /></Button>
 	</p>
 
 	<p class="example-row">
@@ -133,8 +133,8 @@ ${leftIcon || rightIcon ? `import { Close } from 'carbon-icons-svelte'` : ''}
 	</p>
 
 	<p class="example-row">
-		<Typography variant="small" bold>8. Light overlay icon button</Typography>
-		<Button variant="overlay"><SidePanelOpen size={24} /></Button>
+		<Typography variant="small" bold>9. Solid icon button</Typography>
+		<Button variant="solid"><SidePanelOpen size={24} /></Button>
 	</p>
 {/snippet}
 
@@ -151,7 +151,7 @@ ${leftIcon || rightIcon ? `import { Close } from 'carbon-icons-svelte'` : ''}
 		<Option value="strong">Strong button</Option>
 		<Option value="secondary">Outline button</Option>
 		<Option value="ghost">Ghost button</Option>
-		<Option value="overlay">Overlay button</Option>
+		<Option value="solid">Solid button</Option>
 		<Option value="darkoverlay">Dark overlay button</Option>
 	</Select>
 


### PR DESCRIPTION
Fix the button focused state colors according to the design. Also renamed `overlay` to `solid`. `lightoverlay` is missing, that can be done as a separate PR.