### PR TITLE
fix: unstyled focused

### DIFF
--- a/src/app.pcss
+++ b/src/app.pcss
@@ -74,4 +74,3 @@ a {
 		outline: 4px solid var(--colors-top);
 	}
 }
-

--- a/src/app.pcss
+++ b/src/app.pcss
@@ -69,3 +69,9 @@ body {
 a {
 	color: var(--colors-top);
 }
+* {
+	&:focus-visible:not(:disabled) {
+		outline: 4px solid var(--colors-top);
+	}
+}
+


### PR DESCRIPTION
This PR fixes the focused state on native html elements (e.g. links) to look like the focused state on the basic components.