### PR TITLE
refactor: remove unnecessarily prefixed values

### DIFF
--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -75,8 +75,6 @@
 		line-height: 0;
 	}
 	input[type='color'] {
-		-webkit-appearance: none;
-		-moz-appearance: none;
 		appearance: none;
 		cursor: pointer;
 		border: none;


### PR DESCRIPTION
Adding these prefixes is unnecessary as the postcss compiler adds them with autoprefixer plugin.