### PR TITLE
fix: theme selector input

### DIFF
--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -3,12 +3,11 @@
 	import Radio from '../ui/radio-button/radio.svelte'
 	import { ColorPalette } from 'carbon-icons-svelte'
 	import { theme } from '$lib/stores/theme.svelte'
-	import { getEffectiveColorMode } from '$lib/utils/colors'
 	import RadioGroup from '../ui/radio-button/radio-group.svelte'
 	import Button from '../ui/button.svelte'
 
 	// without this line the dropdown does not appear...
-	let effectiveMode = $derived(getEffectiveColorMode(theme.mode))
+	const mode = $derived(theme.mode)
 </script>
 
 <div class="theme-selector">

--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -7,6 +7,7 @@
 	import Button from '../ui/button.svelte'
 
 	// without this line the dropdown does not appear...
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const mode = $derived(theme.mode)
 </script>
 

--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -6,6 +6,7 @@
 	import { calculateLuminance } from '@waku-objects/luminance'
 	import { getEffectiveColorMode } from '$lib/utils/colors'
 	import RadioGroup from '../ui/radio-button/radio-group.svelte'
+	import Button from '../ui/button.svelte'
 
 	let effectiveMode = $derived(getEffectiveColorMode(theme.mode))
 
@@ -30,18 +31,19 @@
 		<Radio value={'system'}>Auto</Radio>
 	</RadioGroup>
 
-	<div class="container">
-		<div class="grow">
-			<Input bind:value={theme.baseColor} type="text" placeholder="Accent color (hex)" />
-		</div>
-		<label>
-			<div class="palette-overlay" />
-			<div class="palette-icon" style={fill}>
-				<ColorPalette size={24} />
-			</div>
-			<input type="color" bind:value={theme.baseColor} id="color" pattern="#(\d{3}|\d{6})" />
-		</label>
-	</div>
+	<Input bind:value={theme.baseColor} type="text" placeholder="Accent color (hex)" label="Accent color" controls={true}>
+		{#snippet buttons()}
+			<Button variant="secondary" style="padding: 0;">
+			<label>
+				<div class="palette-overlay" />
+				<div class="palette-icon" style={fill}>
+					<ColorPalette size={24} />
+				</div>
+				<input type="color" bind:value={theme.baseColor} id="color" pattern="#(\d{3}|\d{6})" />
+			</label>
+			</Button>
+		{/snippet}
+	</Input>
 </div>
 
 <style>

--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -64,8 +64,6 @@
 		line-height: 0;
 	}
 	input[type='color'] {
-		-webkit-appearance: none;
-		-moz-appearance: none;
 		appearance: none;
 		visibility: hidden;
 		cursor: pointer;
@@ -81,17 +79,8 @@
 		border: 0;
 		padding: 0;
 	}
-	input[type='color']::-webkit-color-swatch {
-		margin: 0;
-		outline: 0;
-		border: none;
-		border-radius: 0 var(--border-radius) var(--border-radius) 0;
-		padding: 0;
-		width: 100%;
-		height: 100%;
-	}
+	input[type='color']::-webkit-color-swatch,
 	input[type='color']::-moz-color-swatch {
-		display: flex;
 		margin: 0;
 		outline: 0;
 		border: none;

--- a/src/lib/components/custom/theme-selector.svelte
+++ b/src/lib/components/custom/theme-selector.svelte
@@ -3,22 +3,12 @@
 	import Radio from '../ui/radio-button/radio.svelte'
 	import { ColorPalette } from 'carbon-icons-svelte'
 	import { theme } from '$lib/stores/theme.svelte'
-	import { calculateLuminance } from '@waku-objects/luminance'
 	import { getEffectiveColorMode } from '$lib/utils/colors'
 	import RadioGroup from '../ui/radio-button/radio-group.svelte'
 	import Button from '../ui/button.svelte'
 
+	// without this line the dropdown does not appear...
 	let effectiveMode = $derived(getEffectiveColorMode(theme.mode))
-
-	let fill = $derived(
-		calculateLuminance(theme.baseColor) > 0.5
-			? effectiveMode === 'dark'
-				? 'fill: var(--colors-base)'
-				: 'fill: var(--colors-top)'
-			: effectiveMode === 'dark'
-				? 'fill: var(--colors-top)'
-				: 'fill: var(--colors-base)',
-	)
 </script>
 
 <div class="theme-selector">
@@ -31,16 +21,21 @@
 		<Radio value={'system'}>Auto</Radio>
 	</RadioGroup>
 
-	<Input bind:value={theme.baseColor} type="text" placeholder="Accent color (hex)" label="Accent color" controls={true}>
+	<Input
+		bind:value={theme.baseColor}
+		type="text"
+		placeholder="Accent color (hex)"
+		label="Accent color (hex)"
+		controls={true}
+	>
 		{#snippet buttons()}
 			<Button variant="secondary" style="padding: 0;">
-			<label>
-				<div class="palette-overlay" />
-				<div class="palette-icon" style={fill}>
-					<ColorPalette size={24} />
-				</div>
-				<input type="color" bind:value={theme.baseColor} id="color" pattern="#(\d{3}|\d{6})" />
-			</label>
+				<label>
+					<div class="palette-icon">
+						<ColorPalette size={24} />
+					</div>
+					<input type="color" bind:value={theme.baseColor} id="color" />
+				</label>
 			</Button>
 		{/snippet}
 	</Input>
@@ -57,20 +52,12 @@
 		padding: var(--padding);
 		min-height: fit-content;
 	}
-	.container {
-		display: flex;
-		flex-direction: row;
-		justify-content: stretch;
-		align-items: center;
-		gap: var(--padding);
-	}
 	label {
 		display: flex;
 		position: relative;
 		justify-content: center;
 		align-items: center;
 		cursor: pointer;
-		border-radius: var(--border-radius);
 		width: 3rem;
 		height: 3rem;
 		overflow: hidden;
@@ -80,20 +67,38 @@
 		-webkit-appearance: none;
 		-moz-appearance: none;
 		appearance: none;
+		visibility: hidden;
 		cursor: pointer;
 		border: none;
-		background-color: transparent;
+		background-color: var(--colors-top);
 		padding: 0;
-		width: 3rem;
-		height: 3rem;
+		width: 100%;
+		height: 100%;
+	}
+	input[type='color']::-webkit-color-swatch-wrapper {
+		box-sizing: border-box;
+		margin: 0;
+		border: 0;
+		padding: 0;
 	}
 	input[type='color']::-webkit-color-swatch {
+		margin: 0;
+		outline: 0;
 		border: none;
-		border-radius: var(--border-radius);
+		border-radius: 0 var(--border-radius) var(--border-radius) 0;
+		padding: 0;
+		width: 100%;
+		height: 100%;
 	}
 	input[type='color']::-moz-color-swatch {
+		display: flex;
+		margin: 0;
+		outline: 0;
 		border: none;
-		border-radius: var(--border-radius);
+		border-radius: 0 var(--border-radius) var(--border-radius) 0;
+		padding: 0;
+		width: 100%;
+		height: 100%;
 	}
 	.palette-icon {
 		position: absolute;
@@ -101,17 +106,5 @@
 		inset: 50% auto auto 50%;
 		line-height: 0;
 		fill: var(--colors-top);
-	}
-	.palette-icon :global(svg) {
-		fill: inherit;
-	}
-	.palette-overlay {
-		position: absolute;
-		transform: translate(-50%, -50%);
-		z-index: 5;
-		inset: 50% auto auto 50%;
-		border-radius: var(--border-radius);
-		width: 3rem;
-		height: 3rem;
 	}
 </style>

--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -17,6 +17,7 @@
 		focus?: boolean
 		controls?: boolean
 		disabled?: boolean
+		buttons?: Snippet
 	}
 	let {
 		label,
@@ -35,6 +36,7 @@
 		disabled,
 		class: className = '',
 		children,
+		buttons,
 		...restProps
 	}: Props = $props()
 	let inputValue: number = $state(value)
@@ -80,6 +82,11 @@
 				</Button>
 			</div>
 		{/if}
+		{#if buttons}
+			<div class="control-buttons">
+				{@render buttons()}					
+			</div>
+		{/if}
 		{#if error}
 			<div class="error-message">
 				{@render error()}
@@ -118,7 +125,7 @@
 		.wrapper {
 			flex-direction: row;
 			gap: 0;
-			input[type='number'] {
+			input {
 				border-radius: 0.25rem 0 0 0.25rem;
 			}
 		}

--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -58,7 +58,7 @@
 			class:hover
 			class:focus
 			class:error
-			bind:value={inputValue}
+			bind:value
 			{placeholder}
 			{type}
 			{disabled}
@@ -74,17 +74,17 @@
 		{/if}
 		{#if controls && type === 'number'}
 			<div class="control-buttons">
-				<Button {dimension} {disabled} variant="secondary" onclick={() => (inputValue -= 1)}>
+				<Button {dimension} {disabled} variant="secondary" onclick={() => (value -= 1)}>
 					<Subtract size={dimension === 'small' ? 16 : 24} />
 				</Button>
-				<Button {dimension} {disabled} variant="secondary" onclick={() => (inputValue += 1)}>
+				<Button {dimension} {disabled} variant="secondary" onclick={() => (value += 1)}>
 					<Add size={dimension === 'small' ? 16 : 24} />
 				</Button>
 			</div>
 		{/if}
 		{#if buttons}
 			<div class="control-buttons">
-				{@render buttons()}					
+				{@render buttons()}
 			</div>
 		{/if}
 		{#if error}

--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -39,7 +39,6 @@
 		buttons,
 		...restProps
 	}: Props = $props()
-	let inputValue: number = $state(value)
 </script>
 
 <div class="root {layout} {dimension} {className}" class:controls>


### PR DESCRIPTION
This was trickier to get right than I originally thought. Some issues I ran into:
- In the original version the color chooser button background had the `theme.baseColor`, but I decided to remove this because it did not work well with the focused border of the button. Therefore the color input had to be made invisible inside a label so that it is invoked when the button is pressed. The button's padding also needed to be set to 0 explicitly.
- The `Input` value binding did not work because it made an internal copy of the value in a state variable (`inputValue`) but it never updated the bound value. I fixed it by simply using the `value`.
- There is a line that takes `theme.mode` and stores it in a derived value which is not used, but if that line is removed then the dropdown does not appear. It would be good to understand why and how to fix this.