### PR TITLE
fix: responsive layout

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/components/custom/component-template.svelte
+++ b/src/lib/components/custom/component-template.svelte
@@ -45,7 +45,6 @@
 </VerticalContainer>
 
 <hr />
-
 <section id="use">
 	<Typography class="title" variant="h4" bold>Use</Typography>
 	<VerticalContainer>
@@ -63,9 +62,7 @@
 
 <section id="implement">
 	<Typography class="title" variant="h4" bold>Implement</Typography>
-	<VerticalContainer>
-		{@render implement()}
-	</VerticalContainer>
+	{@render implement()}
 </section>
 
 <hr />

--- a/src/lib/components/custom/highlight-diete.css
+++ b/src/lib/components/custom/highlight-diete.css
@@ -35,6 +35,7 @@ pre code.hljs {
 	display: block;
 	padding: 16px;
 	overflow-x: auto;
+	white-space: break-spaces;
 }
 code.hljs {
 	padding: 3px 5px;

--- a/src/lib/components/custom/tab-bar/tab-bar.svelte
+++ b/src/lib/components/custom/tab-bar/tab-bar.svelte
@@ -53,5 +53,6 @@
 	.tab-container {
 		display: flex;
 		flex-direction: column;
+		width: 100%;
 	}
 </style>

--- a/src/lib/components/custom/vertical-container.svelte
+++ b/src/lib/components/custom/vertical-container.svelte
@@ -16,24 +16,14 @@
 
 <style lang="postcss">
 	.vertical-container {
-		--grid-layout-gap: 16px;
-		--grid-column-count: 2; /* This gets overridden by an inline style. */
-  		--grid-item--min-width: 320px; /* This gets overridden by an inline style. */
-
-		/**
-		* Calculated values.
-		*/
-		--gap-count: calc(var(--grid-column-count) - 1);
-		--total-gap-width: calc(var(--gap-count) * var(--grid-layout-gap));
-		--grid-item--max-width: calc((100% - var(--total-gap-width)) / var(--grid-column-count));
-
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr));
-		grid-gap: var(--grid-layout-gap);
-
-		/* display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+		display: flex;
+		flex-wrap: wrap;
 		gap: 16px;
-		max-width: inherit; */
+
+		:global(section) {
+			flex: 1;
+			box-sizing: border-box;
+			min-width: 320px;
+		}
 	}
 </style>

--- a/src/lib/components/custom/vertical-container.svelte
+++ b/src/lib/components/custom/vertical-container.svelte
@@ -16,9 +16,24 @@
 
 <style lang="postcss">
 	.vertical-container {
+		--grid-layout-gap: 16px;
+		--grid-column-count: 2; /* This gets overridden by an inline style. */
+  		--grid-item--min-width: 320px; /* This gets overridden by an inline style. */
+
+		/**
+		* Calculated values.
+		*/
+		--gap-count: calc(var(--grid-column-count) - 1);
+		--total-gap-width: calc(var(--gap-count) * var(--grid-layout-gap));
+		--grid-item--max-width: calc((100% - var(--total-gap-width)) / var(--grid-column-count));
+
 		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr));
+		grid-gap: var(--grid-layout-gap);
+
+		/* display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 		gap: 16px;
-		max-width: inherit;
+		max-width: inherit; */
 	}
 </style>


### PR DESCRIPTION
The responsive layout was broken due to a regression. I fixed it by getting rid of the grid and also the highlight component no longer requires to be in a `VerticalContainer`.

The real problem is the highlight component trying to take up all the horizontal space so that it can display the longest line in the code. I added a workaround to break the lines, which is not the nicest, it would be better if it just overflowed, but I could not achieve that.